### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/jquery-ui-1.10.4.js
+++ b/src/main/resources/webgoat/static/js/libs/jquery-ui-1.10.4.js
@@ -7224,7 +7224,7 @@ var lastActive, startXPos, startYPos, clickDragged,
 			form = radio.form,
 			radios = $( [] );
 		if ( name ) {
-			name = name.replace( /'/g, "\\'" );
+			name = name.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 			if ( form ) {
 				radios = $( form ).find( "[name='" + name + "']" );
 			} else {


### PR DESCRIPTION
Potential fix for [https://github.com/DanteArcanaelMontford/WebGoat/security/code-scanning/1](https://github.com/DanteArcanaelMontford/WebGoat/security/code-scanning/1)

To fix the problem, we need to ensure that both backslashes and single quotes are properly escaped in the `name` variable before it is interpolated into a selector string. The correct order is to first escape all backslashes (by replacing `\` with `\\`), and then escape all single quotes (by replacing `'` with `\'`). This prevents any backslashes that precede a single quote from interfering with the escaping of the quote itself. The fix should be applied at line 7227 in `src/main/resources/webgoat/static/js/libs/jquery-ui-1.10.4.js`. No new imports are needed, as this can be accomplished with standard JavaScript string methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
